### PR TITLE
Fix image upload and OpenStreetMap duplication issues

### DIFF
--- a/marketplace/static/js/image-preview.js
+++ b/marketplace/static/js/image-preview.js
@@ -61,10 +61,18 @@ document.addEventListener('DOMContentLoaded', function() {
         currentFiles = [...currentFiles, ...validFiles];
         updatePreviews();
         
-        // Update the input's files
+        // Create a new DataTransfer object and add all files
         const dataTransfer = new DataTransfer();
-        currentFiles.forEach(file => dataTransfer.items.add(file));
+        currentFiles.forEach(file => {
+            dataTransfer.items.add(file);
+        });
+        
+        // Update the input's files
         imageInput.files = dataTransfer.files;
+        
+        // Trigger change event to ensure the form knows about the files
+        const changeEvent = new Event('change', { bubbles: true });
+        imageInput.dispatchEvent(changeEvent);
     }
 
     // Handle drag and drop

--- a/marketplace/templates/marketplace/listing_detail.html
+++ b/marketplace/templates/marketplace/listing_detail.html
@@ -763,11 +763,20 @@ function cleanupMap() {
         map.remove();
         map = null;
     }
+    
+    // Also remove any existing leaflet containers
+    const existingMaps = document.querySelectorAll('#listing-map .leaflet-container');
+    existingMaps.forEach(container => {
+        container.remove();
+    });
 }
 
 // Initialize map when page loads
 document.addEventListener('DOMContentLoaded', function() {
     console.log('DOM loaded, initializing page components');
+    // Cleanup any existing map first
+    cleanupMap();
+    
     // Only initialize if map element exists and no map is already created
     if (document.getElementById('listing-map') && !map) {
         initializeMap();
@@ -793,11 +802,8 @@ document.addEventListener('visibilitychange', function() {
 });
 
 function initializeMap() {
-    // Prevent multiple map initializations
-    if (map !== null) {
-        console.log('Map already initialized, skipping...');
-        return;
-    }
+    // Double-check cleanup
+    cleanupMap();
     
     const mapElement = document.getElementById('listing-map');
     if (!mapElement) {


### PR DESCRIPTION
This PR fixes two critical issues in the application:

## Image Upload Issue
Fixed the image upload functionality to properly handle multiple file uploads by:
- Creating a new DataTransfer object with all files
- Triggering a change event after updating the input'sfiles
- Ensuring the form properly recognizes all selected files

## OpenStreetMap Duplication Issue
Fixed the OpenStreetMap component to prevent duplicate map instances by:
- Adding a thorough cleanup function that removes existing Leaflet containers
- Adding cleanup before initialization to prevent duplicate maps
- Maintaining checks to prevent multiple initializations

These changes ensure that:
1. Users can upload multiple images to their listings (previously only one image was uploading)
2. The OpenStreetMap displays only one map instance instead of multiple duplicates

The fixes have been implemented in:
- `marketplace/static/js/image-preview.js` - Updated file handling logic
- `marketplace/templates/marketplace/listing_detail.html` - Improved map initialization and cleanup

## Summary by Sourcery

Fix multiple image upload and prevent duplicate OpenStreetMap instances by improving file handling and adding thorough map cleanup

Bug Fixes:
- Allow multiple image uploads by consolidating files into a DataTransfer object, updating the file input, and dispatching a change event
- Prevent duplicate OpenStreetMap instances by removing existing Leaflet containers and invoking cleanup before initializing the map